### PR TITLE
mlxウィンドウ操作を実装

### DIFF
--- a/includes/config.h
+++ b/includes/config.h
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 21:44:50 by stakada           #+#    #+#             */
-/*   Updated: 2025/08/28 13:30:36 by stakada          ###   ########.fr       */
+/*   Updated: 2025/10/20 12:42:01 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,13 @@
 # define WIN_HEIGHT 800
 # define EXT ".rt"
 # define PROGRAM "./miniRT"
+
+# if defined(__APPLE__)
+#  define ESC_KEY 53
+# else
+#  include <X11/keysym.h>
+#  define ESC_KEY XK_Escape
+# endif
 
 # define VALID 1
 # define INVALID 0

--- a/includes/errors.h
+++ b/includes/errors.h
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 19:42:02 by stakada           #+#    #+#             */
-/*   Updated: 2025/08/28 17:39:52 by stakada          ###   ########.fr       */
+/*   Updated: 2025/10/21 12:38:46 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,5 +32,8 @@
 # define ERR_MSG_MISSING_CAMERA "Missing camera (C)"
 # define ERR_MSG_MISSING_LIGHT "Missing light (L)"
 # define ERR_MSG_NO_OBJECTS "Scene must contain at least one object"
+
+/* System/Runtime errors */
+# define ERR_MSG_MALLOC "Memory allocation failed"
 
 #endif

--- a/includes/miniRT.h
+++ b/includes/miniRT.h
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 13:37:02 by stakada           #+#    #+#             */
-/*   Updated: 2025/08/28 22:26:29 by stakada          ###   ########.fr       */
+/*   Updated: 2025/10/21 12:35:30 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@
 int		check_args(int argc, char **argv);
 
 // init
-t_ctx	*init(char *filename);
+t_ctx	*init_ctx(char *filename);
 
 // parsing
 t_scene	*parse_scene(char *filename);
@@ -49,6 +49,10 @@ int		validate_colors(t_color color);
 int		validate_vec3(t_vec3 vec, double min, double max);
 
 int		register_object(t_object **objects, t_obj_type type, void *obj);
+
+// mlx
+void	my_mlx_pixel_put(t_img *img, int x, int y, int color);
+void	run_mlx(t_ctx *ctx);
 
 // utils
 int		count_array(char **array);

--- a/srcs/free.c
+++ b/srcs/free.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 19:17:57 by stakada           #+#    #+#             */
-/*   Updated: 2025/08/28 16:51:48 by stakada          ###   ########.fr       */
+/*   Updated: 2025/10/20 12:14:15 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,22 +45,13 @@ void	free_scene(t_scene *scene)
 	}
 }
 
-void	free_img(t_img *img)
-{
-	if (img->img)
-		free(img->img);
-	if (img->addr)
-		free(img->addr);
-}
-
 void	free_ctx(t_ctx *ctx)
 {
-	if (ctx->mlx)
-		free(ctx->mlx);
-	if (ctx->win)
-		free(ctx->win);
+	if (!ctx)
+		return ;
 	if (ctx->img)
-		free_img(ctx->img);
+		free(ctx->img);
 	if (ctx->scene)
 		free_scene(ctx->scene);
+	free(ctx);
 }

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -6,14 +6,14 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/27 19:26:43 by stakada           #+#    #+#             */
-/*   Updated: 2025/08/28 22:19:50 by stakada          ###   ########.fr       */
+/*   Updated: 2025/10/20 12:17:52 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "miniRT.h"
 
 // TODO: delete debug statement
-t_ctx	*init(char *filename)
+t_ctx	*init_ctx(char *filename)
 {
 	t_ctx	*ctx;
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 13:36:13 by stakada           #+#    #+#             */
-/*   Updated: 2025/08/28 16:12:54 by stakada          ###   ########.fr       */
+/*   Updated: 2025/10/20 12:39:10 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,9 @@ int	main(int argc, char **argv)
 
 	if (check_args(argc, argv) < 0)
 		return (1);
-	ctx = init(argv[1]);
+	ctx = init_ctx(argv[1]);
 	if (!ctx)
 		return (1);
+	run_mlx(ctx);
 	return (0);
 }

--- a/srcs/mlx.c
+++ b/srcs/mlx.c
@@ -1,0 +1,61 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   mlx.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/10/20 11:52:01 by stakada           #+#    #+#             */
+/*   Updated: 2025/10/21 12:39:03 by stakada          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "miniRT.h"
+
+void	my_mlx_pixel_put(t_img *img, int x, int y, int color)
+{
+	char	*dst;
+
+	if (x >= 0 && x < WIN_WIDTH && y >= 0 && y < WIN_HEIGHT)
+	{
+		dst = img->addr + (y * img->line_length + x * (img->bpp / 8));
+		*(unsigned int *)dst = color;
+	}
+}
+
+// TODO: Linux needs mlx_destroy_display() after mlx_destroy_window()
+int	close_window(t_ctx *ctx)
+{
+	mlx_destroy_image(ctx->mlx, ctx->img->img);
+	mlx_destroy_window(ctx->mlx, ctx->win);
+	free_ctx(ctx);
+	exit(0);
+	return (0);
+}
+
+int	handle_key_input(int keycode, t_ctx *ctx)
+{
+	if (keycode == ESC_KEY)
+		close_window(ctx);
+	return (0);
+}
+
+void	run_mlx(t_ctx *ctx)
+{
+	ctx->mlx = mlx_init();
+	ctx->win = mlx_new_window(ctx->mlx, WIN_WIDTH, WIN_HEIGHT, "miniRT");
+	ctx->img = (t_img *)ft_calloc(1, sizeof(t_img));
+	if (!ctx->img)
+	{
+		print_error(ERR_MSG_MALLOC);
+		close_window(ctx);
+		return ;
+	}
+	ctx->img->img = mlx_new_image(ctx->mlx, WIN_WIDTH, WIN_HEIGHT);
+	ctx->img->addr = mlx_get_data_addr(ctx->img->img, &ctx->img->bpp,
+			&ctx->img->line_length, &ctx->img->endian);
+	mlx_put_image_to_window(ctx->mlx, ctx->win, ctx->img->img, 0, 0);
+	mlx_hook(ctx->win, 2, 1L << 0, handle_key_input, ctx);
+	mlx_hook(ctx->win, 17, 1L << 5, close_window, ctx);
+	mlx_loop(ctx->mlx);
+}


### PR DESCRIPTION
## 概要
- mlx初期化、およびウィンドウの起動と操作を実装
- 描画用`my_mlx_pixel_put`関数の追加
- 関数名をリファクタリング

## 関連issue
なし

## 変更点
- `mlx.c` にMLXウィンドウ関連の関数を新規実装
- ソースコード内の関数名を一部リファクタリング
- メモリ確保失敗時のエラーメッセージを追加
- ESCキーの設定を追加

## 懸念点
- Linux対応の際は `mlx_destroy_display()` の追加が必要
- Linux環境では動作確認できていません

## レビュー観点
- 実装したウィンドウ起動・操作部分、pixel_putの処理内容が問題ないか
- メモリ解放処理の漏れやエラー処理などが適切か

## その他
