### PR TITLE
[feat] put_info関数を追加し、操作情報をウィンドウに表示

### DIFF
--- a/includes/miniRT.h
+++ b/includes/miniRT.h
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 13:37:02 by stakada           #+#    #+#             */
-/*   Updated: 2026/02/13 23:37:26 by stakada          ###   ########.fr       */
+/*   Updated: 2026/02/15 02:19:05 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,9 @@ void	my_mlx_pixel_put(t_img *img, int x, int y, int color);
 void	run_mlx(t_ctx *ctx);
 int		close_window(t_ctx *ctx);
 void	re_render(t_ctx *ctx);
+
+// put_info
+void	put_info(t_ctx *ctx);
 
 // transform
 void	translate_target(t_ctx *ctx, t_vec3 delta);

--- a/includes/render.h
+++ b/includes/render.h
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/11 21:15:08 by stakada           #+#    #+#             */
-/*   Updated: 2026/02/14 00:06:22 by stakada          ###   ########.fr       */
+/*   Updated: 2026/02/15 02:18:53 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,10 @@
 # define RENDER_H
 
 # include "ctx.h"
+
+# define TEXT_COLOR 0xFFFFFF
+# define MARGIN 10
+# define LINE_HEIGHT 20
 
 typedef struct s_camera_frame
 {

--- a/srcs/mlx.c
+++ b/srcs/mlx.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/20 11:52:01 by stakada           #+#    #+#             */
-/*   Updated: 2026/02/14 21:54:33 by stakada          ###   ########.fr       */
+/*   Updated: 2026/02/15 01:45:50 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,7 @@ void	re_render(t_ctx *ctx)
 {
 	render_scene(ctx);
 	mlx_put_image_to_window(ctx->mlx, ctx->win, ctx->img->img, 0, 0);
+	put_info(ctx);
 }
 
 void	run_mlx(t_ctx *ctx)
@@ -55,6 +56,7 @@ void	run_mlx(t_ctx *ctx)
 			&ctx->img->line_length, &ctx->img->endian);
 	render_scene(ctx);
 	mlx_put_image_to_window(ctx->mlx, ctx->win, ctx->img->img, 0, 0);
+	put_info(ctx);
 	mlx_hook(ctx->win, 2, 1L << 0, handle_key_input, ctx);
 	mlx_hook(ctx->win, 17, 1L << 5, close_window, ctx);
 	mlx_loop(ctx->mlx);

--- a/srcs/put_info.c
+++ b/srcs/put_info.c
@@ -1,0 +1,95 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   put_info.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/02/15 00:30:30 by stakada           #+#    #+#             */
+/*   Updated: 2026/02/15 02:18:32 by stakada          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "miniRT.h"
+
+static char	*get_obj_name(t_obj_type type)
+{
+	if (type == SPHERE)
+		return ("Sphere");
+	if (type == PLANE)
+		return ("Plane");
+	if (type == CYLINDER)
+		return ("Cylinder");
+	return ("Unknown");
+}
+
+static void	put_camera_info(t_ctx *ctx)
+{
+	if (!ctx)
+		return ;
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 4, TEXT_COLOR,
+		"Mode: Camera Control");
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 5, TEXT_COLOR,
+		" Move: W, A, S, D, Q, E");
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 6, TEXT_COLOR,
+		" Rotate: Arrow keys");
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 7, TEXT_COLOR,
+		" FOV: + (Increase), - (Decrease)");
+}
+
+static void	put_light_info(t_ctx *ctx)
+{
+	if (!ctx)
+		return ;
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 4, TEXT_COLOR,
+		"Mode: Light Control");
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 5, TEXT_COLOR,
+		" Move: W, A, S, D, Q, E");
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 6, TEXT_COLOR,
+		" Brightness: + (Increase), - (Decrease)");
+}
+
+static void	put_object_info(t_ctx *ctx)
+{
+	int		line;
+	char	mode_info[100];
+
+	if (!ctx || !ctx->selected_object)
+		return ;
+	line = 4;
+	ft_strlcpy(mode_info, "Mode: Object Control (", 100);
+	ft_strlcat(mode_info, get_obj_name(ctx->selected_object->type), 100);
+	ft_strlcat(mode_info, ")", 100);
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * line++, TEXT_COLOR,
+		mode_info);
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * line++, TEXT_COLOR,
+		" Switch Object: TAB");
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * line++, TEXT_COLOR,
+		" Move: W, A, S, D, Q, E");
+	if (ctx->selected_object->type != SPHERE)
+		mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * line++,
+			TEXT_COLOR, " Rotate: Arrow keys");
+	if (ctx->selected_object->type == SPHERE
+		|| ctx->selected_object->type == CYLINDER)
+		mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * line++,
+			TEXT_COLOR, " Diameter: + (Increase), - (Decrease)");
+	if (ctx->selected_object->type == CYLINDER)
+		mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * line++,
+			TEXT_COLOR, " Height: H (Increase), J (Decrease)");
+}
+
+void	put_info(t_ctx *ctx)
+{
+	if (!ctx)
+		return ;
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 1, TEXT_COLOR,
+		"Change Mode: 1 (Camera), 2 (Light), 3 (Object)");
+	mlx_string_put(ctx->mlx, ctx->win, MARGIN, LINE_HEIGHT * 2, TEXT_COLOR,
+		"Quit: ESC");
+	if (ctx->edit_mode == MODE_CAMERA)
+		put_camera_info(ctx);
+	else if (ctx->edit_mode == MODE_LIGHT)
+		put_light_info(ctx);
+	else
+		put_object_info(ctx);
+}


### PR DESCRIPTION
## 概要
`put_info` 関数を追加し、現在の編集モードや操作方法をウィンドウ内へオーバーレイ表示できるようにしました。  
これにより、カメラ・ライト・オブジェクト編集時のキーバインドが一目で把握でき、操作性が向上します。

## 関連issue
#19 

## 変更点
- `put_info.c` を追加（編集モード・選択中のオブジェクト情報とそれに応じた情報表示を実装）
- 毎フレーム、画像描画後に操作情報をオーバーレイ表示するよう`re_render` および `run_mlx` の描画処理後に `put_info` 呼び出しを追加

## 懸念点
- 表示位置・行間 (`MARGIN`, `LINE_HEIGHT`) は暫定値のため、ウィンドウサイズやシーン内容によっては見づらい可能性あり

## レビュー観点
- キーバインド表記が実際の挙動と齟齬がないか
- 文言・英語表記の妥当性
- `put_info` の呼び出しタイミング

## その他
- 表示内容やレイアウトに関する改善案（例: 色分け、枠線など）があればコメントください。
