### PR TITLE
Developブランチの変更をrelease/submission-1へマージ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ ARCH		?= $(shell uname -m || echo unknown)
 ifeq ($(shell uname -s),Darwin)
 	PLATFORM		:= macOS
 	PLATFORM_DIR	:= mac
-	THREADS			:= $(shell sysctl -n hw.ncpu || echo 1)
+	THREADS			:= 1
+# 	THREADS			:= $(shell sysctl -n hw.ncpu || echo 1)
 	OS_LIBFT		:= libft/mac
 	MLX_DIR			:= $(MLX)_macos
 	MLX_A			:= $(MLX_DIR)/libmlx.a
@@ -38,7 +39,8 @@ ifeq ($(shell uname -s),Darwin)
 else
 	PLATFORM		:= $(shell uname -s || echo unknown)
 	PLATFORM_DIR	:= linux
-	THREADS			:= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+	THREADS			:= 1
+# 	THREADS			:= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
 	OS_LIBFT		:= libft/linux
 	MLX_DIR			:= $(MLX)-linux
 	MLX_A			:= $(MLX_DIR)/libmlx_Linux.a


### PR DESCRIPTION
## 概要
提出用ブランチ `release/submission-1` に `develop` ブランチの最新変更を取り込みます。

## 関連issue
なし

## 変更点
- macOS環境でのコンパイル時のスレッド数を `1` に固定
- Linux環境でのコンパイル時のスレッド数を `1` に固定
- 既存のCPUコア数取得処理はコメントアウトし、提出環境向けに挙動を単純化

## 懸念点
なし

## レビュー観点
- 提出環境で問題なくビルドできるか
- 他のターゲット・オプションへの影響がないか

## その他
